### PR TITLE
Allow low-level to clear the environment of the spawned process

### DIFF
--- a/src/me/raynes/conch/low_level.clj
+++ b/src/me/raynes/conch/low_level.clj
@@ -11,12 +11,15 @@
   and enviroment will be set to what you specify. If you pass
   :verbose and it is true, commands will be printed. If it is set to
   :very, environment variables passed, dir, and the command will be
-  printed."
+  printed. If passed the :clear-env keyword option, then the process
+  will not inherit its environment from its parent process."
   [& args]
   (let [[cmd args] (split-with (complement keyword?) args)
         args (apply hash-map args)
         builder (ProcessBuilder. (into-array String cmd))
         env (.environment builder)]
+    (when (:clear-env args)
+      (.clear env))
     (doseq [[k v] (:env args)]
       (.put env k v))
     (when-let [dir (:dir args)]


### PR DESCRIPTION
For my application, I want to only have certain options passed on to the child process.

In this way, conch has changed its behavior from clojure.java.shell and earlier versions of conch, in that the given :env map is only merged into the existing environment, rather than replacing it. If this was instead a regression, I can provide a patch that will revert the original behavior.
