### PR TITLE
remove flatland/useful dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/Raynes/conch"
   :description "A better shell-out library for Clojure."
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.flatland/useful "0.10.6"]]
+  :dependencies [[org.clojure/clojure "1.4.0"]]
   :aliases {"testall" ["with-profile" "dev,default:dev,1.2,default:dev,1.3,default:dev,1.5,default" "test"]}
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.0-master-SNAPSHOT"]]}
              :release {:deploy-repositories {"releases" {:url "https://oss.sonatype.org/service/local/staging/deploy/maven2"

--- a/src/me/raynes/conch.clj
+++ b/src/me/raynes/conch.clj
@@ -1,8 +1,7 @@
 (ns me.raynes.conch
   (:require [me.raynes.conch.low-level :as conch]
             [clojure.java.io :as io]
-            [clojure.string :as string]
-            [flatland.useful.seq :as seq])
+            [clojure.string :as string])
   (:import java.util.concurrent.LinkedBlockingQueue))
 
 (defprotocol Redirectable
@@ -195,11 +194,22 @@
 (defn- program-form [prog]
   `(fn [& args#] (apply execute ~prog args#)))
 
+;; https://github.com/flatland/useful
+(defn map-nth
+  "Calls f on every nth element of coll. If start is passed, starts
+   at that element (counting from zero), otherwise starts with zero."
+  ([f nth coll] (map-nth f 0 nth coll))
+  ([f start nth coll]
+     (map #(% %2)
+          (concat (repeat start identity)
+                  (cycle (cons f (repeat (dec nth) identity))))
+                    coll)))
+
 (defmacro let-programs
   "Like let, but expects bindings to be symbols to strings of paths to
    programs."
   [bindings & body]
-  `(let [~@(seq/map-nth #(program-form %) 1 2 bindings)]
+  `(let [~@(map-nth #(program-form %) 1 2 bindings)]
      ~@body))
 
 (defmacro with-programs


### PR DESCRIPTION
This dependency is unnecessary for just a single function. Removing it will allow projects to use both conch and compojure.