### PR TITLE
Variable arguments for low-level proc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pom.xml
 .lein*
 *jar
 target
+.nrepl-port

--- a/README.md
+++ b/README.md
@@ -408,6 +408,18 @@ When we call `done`, it closes the process's output stream which is
 like sending EOF. The process processes its input and then puts it on
 its input stream where we read it with `stream-to-string`.
 
+### Passing variable arguments and options
+
+If you want to pass pass a variable list of arguments and/or options to a `proc` you can do it like this:
+
+```clojure
+user=> (sh/stream-to-string (sh/proc "echo" ["fee" "fie" "foe" "fum" :verbose :very]) :out)
+echo fee fie foe fum
+"fee fie foe fum\n"
+```
+
+Any vectors of arguments and/or options are flattened with other parameters (including the first parameter, the actual command itself). For example this would work just as well: `["echo" "fee" "fie" ["foe" "fum"] [:verbose :very]]`.
+
 ### Other options
 
 All of conch's streaming and feeding functions (including the lower

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ its input stream where we read it with `stream-to-string`.
 
 ### Passing variable arguments and options
 
-If you want to pass pass a variable list of arguments and/or options to a `proc` you can do it like this:
+If you want to pass a variable list of arguments and/or options to a `proc` you can do it like this:
 
 ```clojure
 user=> (sh/stream-to-string (sh/proc "echo" ["fee" "fie" "foe" "fum" :verbose :very]) :out)

--- a/src/me/raynes/conch/low_level.clj
+++ b/src/me/raynes/conch/low_level.clj
@@ -14,7 +14,7 @@
   printed. If passed the :clear-env keyword option, then the process
   will not inherit its environment from its parent process."
   [& args]
-  (let [[cmd args] (split-with (complement keyword?) args)
+  (let [[cmd args] (split-with (complement keyword?) (flatten args))
         args (apply hash-map args)
         builder (ProcessBuilder. (into-array String cmd))
         env (.environment builder)]
@@ -72,8 +72,8 @@
 
 (defn stream-to
   "Stream :out or :err from a process to an ouput stream.
-  Options passed are fed to clojure.java.io/copy. They are :encoding to 
-  set the encoding and :buffer-size to set the size of the buffer. 
+  Options passed are fed to clojure.java.io/copy. They are :encoding to
+  set the encoding and :buffer-size to set the size of the buffer.
   :encoding defaults to UTF-8 and :buffer-size to 1024."
   [process from to & args]
   (apply io/copy (process from) to args))

--- a/test/me/raynes/conch/low_level_test.clj
+++ b/test/me/raynes/conch/low_level_test.clj
@@ -30,8 +30,20 @@
   (testing "output is put in a string and returned"
     (is (= "foo\n" (c/stream-to-string (c/proc "echo" "foo") :out)))))
 
+(deftest variable-parameters-test
+  (testing "zero parameters can be consumed."
+    (is (= "\n" (c/stream-to-string (c/proc "echo") :out))))
+  (testing "empty parameters can be consumed."
+      (is (= "\n" (c/stream-to-string (c/proc "echo" []) :out))))
+  (testing "single parameter can be consumed."
+      (is (= "fee\n" (c/stream-to-string (c/proc "echo" ["fee"]) :out))))
+  (testing "variable number of parameters can be consumed."
+    (is (= "fee fie foe fum\n" (c/stream-to-string (c/proc "echo" ["fee" "fie" "foe" "fum"]) :out))))
+  (testing "variable number of parameters can be consumed with any nesting."
+    (is (= "fee fie foe fum\n" (c/stream-to-string (c/proc ["echo" ["fee" ["fie" ["foe"]] "fum"]]) :out)))))
+
 (deftest exit-code-test
-  (testing "exit-code blocls until a process exists and returns an exit code."
+  (testing "exit-code blocks until a process exists and returns an exit code."
     (is (= 0 (c/exit-code (c/proc "pwd"))))))
 
 (deftest read-line-test


### PR DESCRIPTION
Hi,

I wanted to be able to pass a variable number of arguments to a proc and I couldn't work out a way of doing it without changing the code of `low_level.clj`.  Maybe I've missed a simpler answer?  However, if there isn't another answer, what I've done is just added `flatten` to the starting bit of `proc`.  I've added some tests to show that it works and an additional bit of documentation in the README.

What do you think?  Useful or not?

Matt