### PR TITLE
remove org.flatland/useful dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,9 @@
-(defproject me.raynes/conch "0.8.0"
+(defproject me.raynes/conch "0.9.0"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/Raynes/conch"
   :description "A better shell-out library for Clojure."
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.flatland/useful "0.10.6"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]]
   :aliases {"testall" ["with-profile" "dev,default:dev,1.5,default:dev,1.4,default" "test"]}
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}

--- a/src/me/raynes/conch.clj
+++ b/src/me/raynes/conch.clj
@@ -1,8 +1,7 @@
 (ns me.raynes.conch
   (:require [me.raynes.conch.low-level :as conch]
             [clojure.java.io :as io]
-            [clojure.string :as string]
-            [flatland.useful.seq :as seq])
+            [clojure.string :as string])
   (:import java.util.concurrent.LinkedBlockingQueue))
 
 (def ^:dynamic *throw*
@@ -254,11 +253,21 @@
 (defn- program-form [prog]
   `(fn [& args#] (apply execute ~prog args#)))
 
+(defn map-nth
+  "Calls f on every nth element of coll. If start is passed, starts
+   at that element (counting from zero), otherwise starts with zero."
+  ([f nth coll] (map-nth f 0 nth coll))
+  ([f start nth coll]
+   (map #(% %2)
+        (concat (repeat start identity)
+                (cycle (cons f (repeat (dec nth) identity))))
+        coll)))
+
 (defmacro let-programs
   "Like let, but expects bindings to be symbols to strings of paths to
    programs."
   [bindings & body]
-  `(let [~@(seq/map-nth #(program-form %) 1 2 bindings)]
+  `(let [~@(map-nth #(program-form %) 1 2 bindings)]
      ~@body))
 
 (defmacro with-programs


### PR DESCRIPTION
Same as the 2 years ago pull request but updated to the current version of the project.

This would make it possible to use the project in a leiningen plugin.

> What are my obligations if I copy source code obtained from Eclipse.org and licensed under the Eclipse Public License and include it in my product that I then distribute?
Source code licensed under the EPL may only be redistributed under the EPL.

https://eclipse.org/legal/eplfaq.php#SRCREDIST